### PR TITLE
[FIX] correct reference path in deleteRef calls to remove 'refs/' prefix

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33658,14 +33658,14 @@ async function run() {
         const diff = await utils.compareBranches(env);
         if (diff.status === 'identical') {
             core.info("No new contributors included! Finishing job");
-            await env.octokit.rest.git.deleteRef({ owner: env.owner, repo: env.repo, ref: `refs/heads/${env.ref}` });
+            await env.octokit.rest.git.deleteRef({ owner: env.owner, repo: env.repo, ref: `heads/${env.ref}` });
             return;
         }
 
         const changedFiles = diff.files.filter(file => file.status !== 'unchanged');
         if (changedFiles.length === 0) {
             core.info("No new contributors included! Finishing job");
-            await env.octokit.rest.git.deleteRef({ owner: env.owner, repo: env.repo, ref: `refs/heads/${env.ref}` });
+            await env.octokit.rest.git.deleteRef({ owner: env.owner, repo: env.repo, ref: `heads/${env.ref}` });
             return;
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -45,14 +45,14 @@ async function run() {
         const diff = await utils.compareBranches(env);
         if (diff.status === 'identical') {
             core.info("No new contributors included! Finishing job");
-            await env.octokit.rest.git.deleteRef({ owner: env.owner, repo: env.repo, ref: `refs/heads/${env.ref}` });
+            await env.octokit.rest.git.deleteRef({ owner: env.owner, repo: env.repo, ref: `heads/${env.ref}` });
             return;
         }
 
         const changedFiles = diff.files.filter(file => file.status !== 'unchanged');
         if (changedFiles.length === 0) {
             core.info("No new contributors included! Finishing job");
-            await env.octokit.rest.git.deleteRef({ owner: env.owner, repo: env.repo, ref: `refs/heads/${env.ref}` });
+            await env.octokit.rest.git.deleteRef({ owner: env.owner, repo: env.repo, ref: `heads/${env.ref}` });
             return;
         }
 


### PR DESCRIPTION
This pull request includes a minor change to the `src/index.js` file. The change corrects the reference format used when deleting a git ref.

* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L48-R55): Corrected the git ref format from `refs/heads/${env.ref}` to `heads/${env.ref}` in the `run` function.