### PR TITLE
feat: allow custom README path for commits

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31662,21 +31662,25 @@ async function commitContributors(env, changes){
     }
 }
 
-async function commitReadme(env, changes){
-    try{
+async function commitReadme(env, changes) {
+    try {
         core.debug(`Committing README changes`);
+        let readme = "README.md";
+        if (changes.path !== undefined) readme = `${changes.path}/README.md`;
+        
         await env.octokit.rest.repos.createOrUpdateFileContents({
             owner: env.owner,
             repo: env.repo,
-            path: "README.md",
+            path: readme,
             sha: changes.sha,
             message: "docs: create or update contributors chart",
             content: changes.content,
             branch: env.ref
         });
+        
         core.debug(`README changes committed`);
-    } catch(error){
-        core.setFailed(`Commit readme changes failed: ${error.message}`, error);
+    } catch (error) {
+        core.setFailed(`Commit readme changes failed: ${error.message}`);
     }
 }
 
@@ -33674,7 +33678,7 @@ async function run() {
         core.debug("Committing contributors data");
         await utils.commitContributors(env, contributorsChartData.images);
         core.debug("Committing updated README");
-        await utils.commitReadme(env, { content: contentEncoded, sha: readme.data.sha });
+        await utils.commitReadme(env, { content: contentEncoded, sha: readme.data.sha, path: path });
 
         const diff = await utils.compareBranches(env);
         if (diff.status === 'identical') {

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ async function run() {
         core.debug("Committing contributors data");
         await utils.commitContributors(env, contributorsChartData.images);
         core.debug("Committing updated README");
-        await utils.commitReadme(env, { content: contentEncoded, sha: readme.data.sha });
+        await utils.commitReadme(env, { content: contentEncoded, sha: readme.data.sha, path: path });
 
         const diff = await utils.compareBranches(env);
         if (diff.status === 'identical') {

--- a/src/utils.js
+++ b/src/utils.js
@@ -154,21 +154,25 @@ async function commitContributors(env, changes){
     }
 }
 
-async function commitReadme(env, changes){
-    try{
+async function commitReadme(env, changes) {
+    try {
         core.debug(`Committing README changes`);
+        let readme = "README.md";
+        if (changes.path !== undefined) readme = `${changes.path}/README.md`;
+        
         await env.octokit.rest.repos.createOrUpdateFileContents({
             owner: env.owner,
             repo: env.repo,
-            path: "README.md",
+            path: readme,
             sha: changes.sha,
             message: "docs: create or update contributors chart",
             content: changes.content,
             branch: env.ref
         });
+        
         core.debug(`README changes committed`);
-    } catch(error){
-        core.setFailed(`Commit readme changes failed: ${error.message}`, error);
+    } catch (error) {
+        core.setFailed(`Commit readme changes failed: ${error.message}`);
     }
 }
 


### PR DESCRIPTION
# New Pull Request
- [ ] Bug fixing
- [x] New features
- [ ] Documentation update

## What did you do?
This pull request includes changes to the `src/index.js` and `src/utils.js` files to enhance the functionality of committing the README file. The most important changes include adding the ability to specify a custom path for the README file and improving error handling in the `commitReadme` function.

Enhancements to committing the README file:

* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L54-R54): Updated the `commitReadme` call to include an optional `path` parameter.
* [`src/utils.js`](diffhunk://#diff-3274f1a37032fb0ae4e2823def0007c634e869ae0dfc304ff6a12c36513c3a52R160-R175): Modified the `commitReadme` function to handle an optional `path` parameter, allowing the README file to be committed to a specified directory if provided.

Improved error handling:

* [`src/utils.js`](diffhunk://#diff-3274f1a37032fb0ae4e2823def0007c634e869ae0dfc304ff6a12c36513c3a52R160-R175): Refined the error message in the `commitReadme` function to remove redundant error information.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Will this be part of a product update?
  > If yes, please write one phrase about this update.
